### PR TITLE
fix: Workspace bug in `check-downstream-compiles`

### DIFF
--- a/.github/actions/check-downstream-compiles/action.yml
+++ b/.github/actions/check-downstream-compiles/action.yml
@@ -30,6 +30,8 @@ runs:
       working-directory: ${{ github.workspace }}/ci-workflows/crates/check-downstream-compiles
       run: |
         cargo run -- --upstream ${{ github.workspace }}/${{ inputs.upstream-path }} --downstream ${{ github.workspace }}/${{ inputs.downstream-path }} --repo ${{ github.repository }} --patch-type ${{ inputs.patch-type }}
+      env:
+        RUST_LOG: "debug"
     - name: Check downstream types don't break spectacularly
       shell: bash 
       working-directory: ${{ github.workspace }}/${{ inputs.downstream-path }}

--- a/crates/check-downstream-compiles/Cargo.toml
+++ b/crates/check-downstream-compiles/Cargo.toml
@@ -6,5 +6,7 @@ edition = "2021"
 [dependencies]
 camino = "1.1.7"
 clap = { version = "4.5.13", features = ["derive"] }
+env_logger = "0.11.5"
+log = "0.4.22"
 toml_edit = "0.22.20"
 walkdir = "2.5.0"


### PR DESCRIPTION
Fixes an issue where `[workspace.dependencies]` were being parsed incorrectly, as we only checked for `[dependencies]`.

Also adds a debug log for CI.

Successful run: https://github.com/argumentcomputer/sphinx/actions/runs/10359219500