### PR TITLE
Switch to commit-mode for changelog

### DIFF
--- a/.github/actions/tag-release/action.yml
+++ b/.github/actions/tag-release/action.yml
@@ -92,6 +92,7 @@ runs:
       id: github-release
       uses: mikepenz/release-changelog-builder-action@v5
       with:
+        mode: "COMMIT"
         configuration: ${{ inputs.changelog-config-file }}
         path: "./${{ inputs.changelog-path }}"
         fromTag: ${{ steps.get-latest-release.outputs.latest-release }}


### PR DESCRIPTION
Switches to commit mode in https://github.com/mikepenz/release-changelog-builder-action (see https://github.com/argumentcomputer/zk-light-clients/pull/268)